### PR TITLE
nautible/issue#64 - quarkus vup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nautible-app-ms-customer project
 このドキュメントには顧客アプリケーションについて記載する。
-アプリケーション共通の内容については[こちら](https://github.com/nautible/docs/app-common/README.md)を参照。
-Quarkusアプリケーション共通の内容については[こちら](https://github.com/nautible/docs/quarkus/README.md)を参照。
+アプリケーション共通の内容については[こちら](https://github.com/nautible/docs/blob/main/referenceapp-architecture/README.md)を参照。
+Quarkusアプリケーション共通の内容については[こちら](https://github.com/nautible/docs/blob/main/reference/quarkus/README.md)を参照。
 
 ## アプリケーションの主要アーキテクチャ
 * [Java11](https://www.oracle.com/java/)
@@ -27,7 +27,7 @@ Quarkusアプリケーション共通の内容については[こちら](https:/
 ### 事前準備
 * [dockerのインストール](https://docs.docker.com/get-docker/)
 * [minikubeのインストール](https://kubernetes.io/ja/docs/tasks/tools/install-minikube/)
-* [kubectlのインストール](https://kubernetes.io/ja/docs/tasks/tools/install-kubectl/)（接続先の設定をminikubeにする
+* [kubectlのインストール](https://kubernetes.io/ja/docs/tasks/tools/install-kubectl/)（接続先の設定をminikubeにする）
 * [skaffoldのインストール](https://skaffold.dev/docs/install/)
 * マニフェストファイルの配置
 [nautible-app-ms-customer-manifest](https://github.com/nautible/nautible-app-ms-customer-manifest)をnautible-app-ms-customerプロジェクトと同一階層に配置する(git clone)。

--- a/nautible-app-ms-customer-aws/pom.xml
+++ b/nautible-app-ms-customer-aws/pom.xml
@@ -4,6 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>nautible-app-ms-customer-aws</artifactId>
   <properties>
+    <quarkus-amazon-services.version>1.3.0</quarkus-amazon-services.version>
   </properties>
 
   <parent>
@@ -11,6 +12,18 @@
     <artifactId>nautible-app-ms-customer-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
+
+  <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkiverse.amazonservices</groupId>
+          <artifactId>quarkus-amazon-services-bom</artifactId>
+          <version>${quarkus-amazon-services.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -29,7 +42,7 @@
     </dependency>
     <!-- dynamodb -->
     <dependency>
-      <groupId>io.quarkus</groupId>
+      <groupId>io.quarkiverse.amazonservices</groupId>
       <artifactId>quarkus-amazon-dynamodb</artifactId>
     </dependency>
     <dependency>
@@ -41,8 +54,8 @@
       <artifactId>netty-nio-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>dynamodb-enhanced</artifactId>
+      <groupId>io.quarkiverse.amazonservices</groupId>
+      <artifactId>quarkus-amazon-dynamodb-enhanced</artifactId>
     </dependency>
   </dependencies>
 

--- a/nautible-app-ms-customer-azure/src/main/java/jp/co/ogis_ri/nautible/app/customer/outbound/cosmosdb/CosmosdbCustomer.java
+++ b/nautible-app-ms-customer-azure/src/main/java/jp/co/ogis_ri/nautible/app/customer/outbound/cosmosdb/CosmosdbCustomer.java
@@ -3,7 +3,7 @@ package jp.co.ogis_ri.nautible.app.customer.outbound.cosmosdb;
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
-import io.quarkus.mongodb.panache.MongoEntity;
+import io.quarkus.mongodb.panache.common.MongoEntity;
 
 /**
  * 顧客ドメイン

--- a/nautible-app-ms-customer-core/pom.xml
+++ b/nautible-app-ms-customer-core/pom.xml
@@ -150,22 +150,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>generated-sources/grpc</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
       <plugin>

--- a/nautible-app-ms-customer-core/pom.xml
+++ b/nautible-app-ms-customer-core/pom.xml
@@ -150,6 +150,22 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>generated-sources/grpc</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
       <plugin>

--- a/nautible-app-ms-customer-core/src/main/java/jp/co/ogis_ri/nautible/app/customer/core/rest/MDCInterceptor.java
+++ b/nautible-app-ms-customer-core/src/main/java/jp/co/ogis_ri/nautible/app/customer/core/rest/MDCInterceptor.java
@@ -1,5 +1,7 @@
 package jp.co.ogis_ri.nautible.app.customer.core.rest;
 
+import java.util.Optional;
+
 import javax.enterprise.inject.spi.CDI;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -27,9 +29,9 @@ public class MDCInterceptor {//implements ContainerRequestFilter, ContainerRespo
     Object logInvocation(InvocationContext context) throws Exception {
         RoutingContext routingContext = CDI.current().select(RoutingContext.class).get();
         HttpServerRequest request = routingContext.request();
-        MDC.put("x-request-id", request.getHeader("x-request-id"));
-        MDC.put("url", request.path());
-        MDC.put("method", request.method());
+        Optional.ofNullable(request.getHeader("x-request-id")).ifPresent(xRequestId -> MDC.put("x-request-id", xRequestId));
+        Optional.ofNullable(request.path()).ifPresent(path -> MDC.put("url", path));
+        Optional.ofNullable(request.method()).ifPresent(method -> MDC.put("method", method));
         Object ret = null;
         try {
             ret = context.proceed();

--- a/nautible-app-ms-customer-core/src/main/java/jp/co/ogis_ri/nautible/app/customer/inbound/grpc/GrpcCustomerServiceImpl.java
+++ b/nautible-app-ms-customer-core/src/main/java/jp/co/ogis_ri/nautible/app/customer/inbound/grpc/GrpcCustomerServiceImpl.java
@@ -9,6 +9,7 @@ import javax.inject.Singleton;
 //import org.eclipse.microprofile.opentracing.Traced;
 
 import io.grpc.stub.StreamObserver;
+import io.quarkus.grpc.GrpcService;
 import jp.co.ogis_ri.nautible.app.customer.api.grpc.CustomerServiceGrpc;
 import jp.co.ogis_ri.nautible.app.customer.api.grpc.Empty;
 import jp.co.ogis_ri.nautible.app.customer.api.grpc.GrpcCreateCustomerRequest;
@@ -27,6 +28,7 @@ import jp.co.ogis_ri.nautible.app.customer.domain.CustomerService;
  * gRPCのサービス。gRPCのエンドポイント。
  */
 @Singleton
+@GrpcService
 public class GrpcCustomerServiceImpl extends CustomerServiceGrpc.CustomerServiceImplBase {
 
     @Inject

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
     <swagger-annotations.version>1.6.2</swagger-annotations.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.13.6.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.13.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.13.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.13.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <openapi.generator.maven.plugin.version>5.0.0</openapi.generator.maven.plugin.version>
     <nautible.app.customer.groupId>jp.co.ogis-ri.nautible.app</nautible.app.customer.groupId>


### PR DESCRIPTION
# issue 64
## issue
- https://github.com/nautible/issues/issues/64

## 対応
- Quarkus の v2.13.0.Finalへのバージョンアップ
- READMEのTYPOとリンク切れ対応

## 詳細

1. MDC実装が変わり、null値をつっこめなくなった
⇒ Optional で組むよう修正
```
Caused by: java.lang.NullPointerException
 at java.base/java.util.Objects.requireNonNull(Objects.java:221)
 at io.quarkus.vertx.core.runtime.VertxMDC.putObject(VertxMDC.java:147)
 at io.quarkus.vertx.core.runtime.VertxMDC.putObject(VertxMDC.java:121)
 at io.quarkus.vertx.mdc.provider.LateBoundMDCProvider.putObject(LateBoundMDCProvider.java:74)
 at org.jboss.logmanager.MDC.putObject(MDC.java:85)
 at org.jboss.logging.JBossLogManagerProvider.putMdc(JBossLogManagerProvider.java:110)
 at org.jboss.logging.MDC.put(MDC.java:41)
```

2. MongoEntityのパッケージが変わった
⇒ 新パッケージへ修正
```
[ERROR]   シンボル:   クラス MongoEntity
[ERROR]   場所: パッケージ io.quarkus.mongodb.panache
```

3. quarkus の DynamoDB ライブラリが新しくなった
⇒ 新ライブラリへの移行
```
[ERROR]         [error]: Build step io.quarkus.amazon.dynamodb.deployment.DynamodbProcessor#createClientBuilders threw an exception: java.lang.NoSuchMethodError: 'void io.quarkus.amazon.dynamodb.deployment.DynamodbProcessor.createClientBuilders(io.quarkus.amazon.common.runtime.AmazonClientRecorder, io.quarkus.runtime.RuntimeValue, io.quarkus.runtime.RuntimeValue, io.quarkus.amazon.common.runtime.SdkBuildTimeConfig, java.util.List, java.util.List, java.lang.Class, java.util.function.Function, java.lang.Class, java.util.function.Function, io.quarkus.deployment.annotations.BuildProducer)'
[ERROR]         at io.quarkus.amazon.dynamodb.deployment.DynamodbProcessor.createClientBuilders(DynamodbProcessor.java:136)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR]         at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[ERROR]         at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
[ERROR]         at io.quarkus.builder.BuildContext.run(BuildContext.java:281)
[ERROR]         at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
[ERROR]         at java.base/java.lang.Thread.run(Thread.java:829)
[ERROR]         at org.jboss.threads.JBossThread.run(JBossThread.java:501)
```

4. gRPCサービスクラスに＠GrpcServiceアノテーションが必要になった

```
io.quarkus.builder.BuildException: Build failure: Build failed due to errors
        [error]: Build step io.quarkus.arc.deployment.ArcProcessor#generateResources threw an exception: javax.enterprise.inject.spi.DeploymentException: java.lang.IllegalStateException: A gRPC service bean must be annotated with @io.quarkus.grpc.GrpcService: CLASS bean [types=[jp.co.ogis_ri.nautible.app.customer.api.grpc.CustomerServiceGrpc$CustomerServiceImplBase, io.grpc.BindableService, jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl, java.lang.Object], qualifiers=[@Default, @Any], target=jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl]
        at io.quarkus.arc.processor.BeanDeployment.processErrors(BeanDeployment.java:1214)
        at io.quarkus.arc.processor.BeanProcessor.processValidationErrors(BeanProcessor.java:153)
        at io.quarkus.arc.deployment.ArcProcessor.generateResources(ArcProcessor.java:549)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
        at io.quarkus.builder.BuildContext.run(BuildContext.java:281)
        at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
        at java.base/java.lang.Thread.run(Thread.java:829)
        at org.jboss.threads.JBossThread.run(JBossThread.java:501)
Caused by: java.lang.IllegalStateException: A gRPC service bean must be annotated with @io.quarkus.grpc.GrpcService: CLASS bean [types=[jp.co.ogis_ri.nautible.app.customer.api.grpc.CustomerServiceGrpc$CustomerServiceImplBase, io.grpc.BindableService, jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl, java.lang.Object], qualifiers=[@Default, @Any], target=jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl]
        at io.quarkus.grpc.deployment.GrpcServerProcessor.validateBindableService(GrpcServerProcessor.java:454)
        at io.quarkus.grpc.deployment.GrpcServerProcessor.validateBindableServices(GrpcServerProcessor.java:446)
        ... 11 more

Caused by: io.quarkus.builder.BuildException:
Build failure: Build failed due to errors
        [error]: Build step io.quarkus.arc.deployment.ArcProcessor#generateResources threw an exception: javax.enterprise.inject.spi.DeploymentException: java.lang.IllegalStateException: A gRPC service bean must be annotated with @io.quarkus.grpc.GrpcService: CLASS bean [types=[jp.co.ogis_ri.nautible.app.customer.api.grpc.CustomerServiceGrpc$CustomerServiceImplBase, io.grpc.BindableService, jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl, java.lang.Object], qualifiers=[@Default, @Any], target=jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl]
        at io.quarkus.arc.processor.BeanDeployment.processErrors(BeanDeployment.java:1214)
        at io.quarkus.arc.processor.BeanProcessor.processValidationErrors(BeanProcessor.java:153)
        at io.quarkus.arc.deployment.ArcProcessor.generateResources(ArcProcessor.java:549)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
        at io.quarkus.builder.BuildContext.run(BuildContext.java:281)
        at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
        at java.base/java.lang.Thread.run(Thread.java:829)
        at org.jboss.threads.JBossThread.run(JBossThread.java:501)
Caused by: java.lang.IllegalStateException: A gRPC service bean must be annotated with @io.quarkus.grpc.GrpcService: CLASS bean [types=[jp.co.ogis_ri.nautible.app.customer.api.grpc.CustomerServiceGrpc$CustomerServiceImplBase, io.grpc.BindableService, jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl, java.lang.Object], qualifiers=[@Default, @Any], target=jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl]
        at io.quarkus.grpc.deployment.GrpcServerProcessor.validateBindableService(GrpcServerProcessor.java:454)
        at io.quarkus.grpc.deployment.GrpcServerProcessor.validateBindableServices(GrpcServerProcessor.java:446)
        ... 11 more

Caused by: javax.enterprise.inject.spi.DeploymentException: java.lang.IllegalStateException: A gRPC service bean must be annotated with @io.quarkus.grpc.GrpcService: CLASS bean [types=[jp.co.ogis_ri.nautible.app.customer.api.grpc.CustomerServiceGrpc$CustomerServiceImplBase, io.grpc.BindableService, jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl, java.lang.Object], qualifiers=[@Default, @Any], target=jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl]
Caused by: java.lang.IllegalStateException: A gRPC service bean must be annotated with @io.quarkus.grpc.GrpcService: CLASS bean [types=[jp.co.ogis_ri.nautible.app.customer.api.grpc.CustomerServiceGrpc$CustomerServiceImplBase, io.grpc.BindableService, jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl, java.lang.Object], qualifiers=[@Default, @Any], target=jp.co.ogis_ri.nautible.app.customer.inbound.grpc.GrpcCustomerServiceImpl]
```
